### PR TITLE
Add additional core tests

### DIFF
--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { store, action, actions } from '@renewx/core';
+
+describe('actions', () => {
+  it('creates single action that updates store', () => {
+    const counter = store(0);
+    const inc = action(counter, (state: number, v: number) => state + v);
+    inc(2);
+    expect(counter.get()).toBe(2);
+  });
+
+  it('groups actions and exposes store interface', () => {
+    const s = store(1);
+    const group = actions(s, {
+      add: (state: number, x: number) => state + x,
+      sub: (state: number, x: number) => state - x,
+    });
+
+    expect(group.store).toBe(s);
+    expect(group.set).toBe(s.set);
+
+    group.add(4);
+    expect(s.get()).toBe(5);
+    group.sub(2);
+    expect(s.get()).toBe(3);
+
+    group.off();
+    group.add(1);
+    expect(s.get()).toBe(3);
+  });
+});

--- a/packages/core/tests/creator.test.ts
+++ b/packages/core/tests/creator.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { store, creator } from '@renewx/core';
+
+describe('creator', () => {
+  it('wraps initialization and cleanup', () => {
+    const createCounter = creator(() => {
+      const s = store(0);
+      return { store: s };
+    });
+
+    const c = createCounter();
+    expect(typeof c.off).toBe('function');
+    c.store.set(5);
+    expect(c.store.get()).toBe(5);
+    c.off();
+    expect(c.store.isOff()).toBe(true);
+  });
+});

--- a/packages/core/tests/is.test.ts
+++ b/packages/core/tests/is.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { store, isAnyStore, isActionStore } from '@renewx/core';
+import { isStateChanged } from '../src/utils/is';
+
+describe('utils/is', () => {
+  it('detects state changes correctly', () => {
+    expect(isStateChanged({ a: 1 }, { a: 1 })).toBe(false);
+    expect(isStateChanged({ a: 1 }, { a: 2 })).toBe(true);
+    expect(isStateChanged({ a: { b: 1 } }, { a: { b: 1 } })).toBe(false);
+    expect(isStateChanged({ a: { b: 1 } }, { a: { b: 2 } })).toBe(true);
+    expect(isStateChanged({ a: 1 }, { a: 1, c: 2 })).toBe(true);
+  });
+
+  it('identifies store types', () => {
+    const s = store(0);
+    expect(isAnyStore(s)).toBe(true);
+    expect(isAnyStore({})).toBe(false);
+    expect(isActionStore(s)).toBe(true);
+    expect(isActionStore(s.readOnly)).toBe(false);
+  });
+});

--- a/packages/core/tests/set-diff-un-interval.test.ts
+++ b/packages/core/tests/set-diff-un-interval.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { setDiffUnInterval } from '@renewx/core';
+
+describe('setDiffUnInterval', () => {
+  it('calls with time difference and stops on unsubscribe', () => {
+    vi.useFakeTimers();
+    const diffs: number[] = [];
+    const un = setDiffUnInterval((d) => diffs.push(d), 100);
+    vi.advanceTimersByTime(250);
+    un();
+    expect(diffs).toEqual([100, 100, 50]);
+    vi.advanceTimersByTime(500);
+    expect(diffs).toEqual([100, 100, 50]);
+    vi.useRealTimers();
+  });
+
+  it('handles unsubscribe during tick', () => {
+    vi.useFakeTimers();
+    const diffs: number[] = [];
+    let un: () => void;
+    un = setDiffUnInterval((d) => {
+      diffs.push(d);
+      un();
+    }, 100);
+    vi.advanceTimersByTime(100);
+    expect(diffs).toEqual([100]);
+    vi.advanceTimersByTime(200);
+    expect(diffs).toEqual([100]);
+    vi.useRealTimers();
+  });
+});

--- a/packages/core/tests/setup.test.ts
+++ b/packages/core/tests/setup.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { store, watch, setup } from '@renewx/core';
+
+describe('setup', () => {
+  it('creates reusable watcher with cleanup', () => {
+    const values: number[] = [];
+    const setupWatcher = setup((cleaner, s: ReturnType<typeof store>) => {
+      cleaner.add(watch(s, (v) => values.push(v)));
+    });
+
+    const s = store(0);
+    const c = setupWatcher(s);
+    s.set(1);
+    expect(values).toEqual([0, 1]);
+    c.off();
+    s.set(2);
+    expect(values).toEqual([0, 1]);
+  });
+});

--- a/packages/core/tests/tx.test.ts
+++ b/packages/core/tests/tx.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { store, tx } from '@renewx/core';
+
+describe('tx', () => {
+  it('commits changes to multiple stores', async () => {
+    const a = store(1);
+    const b = store(2);
+    const update = tx([a, b], async ([at, bt], x: number, y: number) => {
+      at.set(at.get() + x);
+      bt.set(bt.get() + y);
+      return at.get() + bt.get();
+    });
+
+    const result = await update(3, 4);
+    expect(result).toBe(10);
+    expect(a.get()).toBe(4);
+    expect(b.get()).toBe(6);
+  });
+
+  it('rolls back when state changes during transaction', async () => {
+    vi.useFakeTimers();
+    const s = store(0);
+    const op = tx([s], async ([st], v: number) => {
+      await new Promise((r) => setTimeout(r, 10));
+      st.set(st.get() + v);
+    });
+
+    const p = op(5);
+    vi.advanceTimersByTime(5);
+    s.set(1);
+    vi.advanceTimersByTime(10);
+
+    await expect(p).rejects.toThrow();
+    expect(s.get()).toBe(1);
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for actions and grouping
- test creator initialization wrapper
- test reusable setup
- verify diff interval logic
- add unit tests for utility functions
- cover transaction behavior
- fix utils and setup tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685301f518fc83219ed7d529ece9939d